### PR TITLE
Only output placeholders for the supported master brand.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "o-editorial-typography": "^1.0.0",
     "o-typography": "^6.1.0",
     "o-quote": "^4.0.0",
-    "o-spacing": "^2.0.0"
+    "o-spacing": "^2.0.0",
+    "o-brand": "^3.2.8"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -2,6 +2,7 @@
 @import 'o-spacing/main';
 @import 'o-typography/main';
 @import 'o-quote/main';
+@import 'o-brand/main';
 
 @import 'src/scss/variables';
 @import 'src/scss/functions';

--- a/origami.json
+++ b/origami.json
@@ -9,6 +9,9 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"
 	},
+	"brands": [
+		"master"
+	],
 	"supportStatus": "active",
 	"browserFeatures": {
 		"required": [

--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -1,4 +1,6 @@
-@if $_o-editorial-layout-placeholders-output == false {
+// Only output placeholders if the current brand is the master brand.
+// This allows components which support multiple brands to use o-editorial-layout.
+@if $_o-editorial-layout-placeholders-output == false and oBrandGetCurrentBrand() == 'master' {
     // Only output placeholders once.
     $_o-editorial-layout-placeholders-output: true !global;
 


### PR DESCRIPTION
This allows components which support multiple brands to use
o-editorial-layout (e.g o-quote).