### PR TITLE
Use new editorial quote style.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "o-editorial-typography": "^1.0.0",
     "o-typography": "^6.1.0",
-    "o-quote": "^4.0.0",
+    "o-quote": "^4.1.2",
     "o-spacing": "^2.0.0",
     "o-brand": "^3.2.8"
   }

--- a/main.scss
+++ b/main.scss
@@ -111,19 +111,17 @@
 			}
 
 			> blockquote {
-				@include oQuoteBase();
-				@include oQuoteStandard();
+				@include oQuoteEditorial();
 				margin-bottom: oSpacingByIncrement(7);
 				max-width: oTypographyMaxLineWidth(75);
 
 				cite,
 				footer {
-					@include oQuoteBaseCite();
-					@include oQuoteStandardCite();
+					@include oQuoteEditorialCite();
 				}
 
 				footer > cite {
-					@include oQuoteStandardCiteAuthor();
+					@include oQuoteEditorialCiteAuthor();
 				}
 			}
 		}


### PR DESCRIPTION
Designed by Josh in the Content Innovation Team.
Background: https://github.com/Financial-Times/o-quote/issues/51

before
<img width="589" alt="Screenshot 2020-04-24 at 11 02 26" src="https://user-images.githubusercontent.com/10405691/80201008-5fefa000-861b-11ea-8e9c-dba3b3054f5e.png">

after
<img width="639" alt="Screenshot 2020-04-24 at 11 02 03" src="https://user-images.githubusercontent.com/10405691/80201001-5ebe7300-861b-11ea-98c1-8c4448db4f25.png">