### PR TITLE
Correct blockquote styles within the wrapper class.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -82,6 +82,7 @@
 				@include oEditorialLayoutHeading(5);
 			}
 
+			> blockquote,
 			> ol,
 			> ul,
 			> p {


### PR DESCRIPTION
Since `o-quote--editorial` was updated to inherit font size:
https://github.com/Financial-Times/o-quote/pull/68