### PR TITLE
Include fonts by default.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -24,6 +24,15 @@
 		@error ('The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5)`.');
 	}
 
+	// Load fonts within the primary mixin in-case silent mode is on.
+	// Don't load fonts if o-typography has output them already since
+	// `$o-editorial-layout-load-fonts` was set.
+	@if $o-editorial-layout-load-fonts == true and $o-typography-load-fonts == true {
+		@include oFonts();
+		// Set to false so fonts are not output twice by o-editorial-typography.
+		$o-editorial-layout-load-fonts: false !global;
+	}
+
 	@if index($headings, 1) {
 		.o-editorial-layout-heading-1 {
 			@include oEditorialLayoutHeading(1);

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,2 +1,11 @@
 $o-editorial-layout-is-silent: true !default;
 $_o-editorial-layout-placeholders-output: false !default;
+
+/// If true, include fonts from o-fonts.
+///
+/// Defaults to the value of `$o-editorial-typography-load-fonts`. If you are
+/// using o-typography or o-editorial-typography and have already indicated not
+/// to load fonts, preferring to load fonts manually, this variable does not
+/// need to be set. If you are not using `o-typography`, set this to false to
+/// load fonts manually.
+$o-editorial-layout-load-fonts: $o-editorial-typography-load-fonts !default;


### PR DESCRIPTION
So users may include `o-editorial-layout` without include `o-fonts`
manually. If the user is also including either `o-editorial-typography`
or `o-typography` and has set a variable to not include fonts that
is passed through. If the user is only including `o-editorial-layout`
they can set `$o-editorial-layout-load-fonts: false;` to opt-out
of font inclusion e.g. they may have included fonts in a seperate
entry point.