### PR TITLE
Increase the bottom margin of h2 and h3 editorial headings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 /node_modules/
 /build/
 .idea/
-/demos/local
+demos/local
 /coverage

--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -18,20 +18,15 @@
 	}
 	// h2
 	// - large margin above by default
-	// - small margin below by default
+	// - medium margin below by default
 	%_o-editorial-layout-heading-2 {
-		margin-bottom: oSpacingByName('s1');
+		margin-bottom: oSpacingByName('s2');
 		margin-top: oSpacingByName('s8');
 	}
-	// h3
 
-	// - small margin below by default
-	%_o-editorial-layout-heading-3 {
-		margin-bottom: oSpacingByName('s1');
-		margin-top: 0;
-	}
-	// h4
+	// h3 & h4
 	// - medium margin below by default
+	%_o-editorial-layout-heading-3,
 	%_o-editorial-layout-heading-4 {
 		margin-bottom: oSpacingByName('s3');
 		margin-top: 0;


### PR DESCRIPTION
Requested by Kevin (Editorial Creative Director) and Mus (Head of
Editorial Platforms). 

See Percy screenshots.

This will need to be backported to the previous major (which supports Bower) and a new
release of [n-content-body](https://github.com/Financial-Times/n-content-body/blob/35a1da5120a0a905b3ebd86f0d80e8a33243fb84/bower.json#L21) made to make it to ft.com and the app.

Closes: https://financialtimes.atlassian.net/browse/CI-793

The ticket discusses h3 only, but h2 was added as discussed in a
follow up meeting.