### PR TITLE
v1 Backport: Increase the bottom margin of h2 and h3 editorial headings.

### DIFF
--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -18,20 +18,15 @@
 	}
 	// h2
 	// - large margin above by default
-	// - small margin below by default
+	// - medium margin below by default
 	%_o-editorial-layout-heading-2 {
-		margin-bottom: oSpacingByName('s1');
+		margin-bottom: oSpacingByName('s2');
 		margin-top: oSpacingByName('s8');
 	}
-	// h3
 
-	// - small margin below by default
-	%_o-editorial-layout-heading-3 {
-		margin-bottom: oSpacingByName('s1');
-		margin-top: 0;
-	}
-	// h4
+	// h3 & h4
 	// - medium margin below by default
+	%_o-editorial-layout-heading-3,
 	%_o-editorial-layout-heading-4 {
 		margin-bottom: oSpacingByName('s3');
 		margin-top: 0;


### PR DESCRIPTION
Backports https://github.com/Financial-Times/o-editorial-layout/pull/52

Requested by Kevin (Editorial Creative Director) and Mus (Head of
Editorial Platforms).

Closes: https://financialtimes.atlassian.net/browse/CI-793

The ticket discusses h3 only, but h2 was added as discussed in a
follow up meeting.